### PR TITLE
Ea 4.14.98

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <remote fetch="git://github.com/openembedded" name="oe"/>
   <remote fetch="git://github.com/OSSystems" name="OSSystems"/>
   <remote fetch="git://github.com/meta-qt5"  name="QT5"/>
-  <remote fetch="git://github.com/embeddedartists"  name="EA"/>
+  <remote fetch="git://github.com/bchen-murata"  name="EA"/>
   <remote fetch="git://github.com/bchen-murata"  name="Murata"/>
 
   <remote fetch="https://source.codeaurora.org/external/imx" name="CAF"/>
@@ -31,10 +31,10 @@
 
   <project remote="CAF" revision="c2602efbe743dbe5e7907646694d772144b56b2d" name="meta-fsl-bsp-release" path="sources/meta-fsl-bsp-release" />
 
-  <project remote="EA" name="meta-ea" path="sources/meta-ea" revision="eb74109baa704fa52f3529bc746a0c088feb4019" >
+  <project remote="EA" name="meta-ea" path="sources/meta-ea" revision="7db2942922b06c66d9e9b6a3392e9580800cd366" >
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="585106e7b03f318fc9ce95857de4163a9c635770" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="ec8dae5aae5217c92c2d94f76c8939a688a04e54" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="ec8dae5aae5217c92c2d94f76c8939a688a04e54" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="cf3d21c0cdc80e203326d0996ab618d8517095fe" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="821687534c751bc0092a5173aeb2de591774ed62" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="0c76c11b555570e264878d570d4f78654f989073" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="971946f78855fd89004ce9f2595083b01d141d85" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="821687534c751bc0092a5173aeb2de591774ed62" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="e5f9cf9df32c2e172a396adce7212cd642bf3186" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="478a5740d5b7ec2b5ddf278f377b49d56bbb205f" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="0c76c11b555570e264878d570d4f78654f989073" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="4f6f771f96ab1ffc8b591537fe2c5714daed92f8" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="cf3d21c0cdc80e203326d0996ab618d8517095fe" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="e5f9cf9df32c2e172a396adce7212cd642bf3186" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <remote fetch="git://github.com/OSSystems" name="OSSystems"/>
   <remote fetch="git://github.com/meta-qt5"  name="QT5"/>
   <remote fetch="git://github.com/bchen-murata"  name="EA"/>
-  <remote fetch="git://github.com/bchen-murata"  name="Murata"/>
+  <remote fetch="git://github.com/murata-wireless"  name="Murata"/>
 
   <remote fetch="https://source.codeaurora.org/external/imx" name="CAF"/>
 
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="0e778f04a11e24f9c5fb8b775c49e89e4f232903" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="e9c69a2d7aa29b08df2243250bc64bd552a71dfc" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="478a5740d5b7ec2b5ddf278f377b49d56bbb205f" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="073fb1b445b6df01bb2d5e2abf01ec0e826b8939" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="4f6f771f96ab1ffc8b591537fe2c5714daed92f8" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="0e778f04a11e24f9c5fb8b775c49e89e4f232903" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="379df418738e5bedb54946aedb1fe2c5559bf5c5" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="971946f78855fd89004ce9f2595083b01d141d85" />
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -35,6 +35,6 @@
      <copyfile src="ea-setup-release.sh" dest="ea-setup-release.sh"/>
   </project>
 
-  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="073fb1b445b6df01bb2d5e2abf01ec0e826b8939" />
+  <project remote="Murata" name="meta-murata-wireless" path="sources/meta-murata-wireless" revision="379df418738e5bedb54946aedb1fe2c5559bf5c5" />
 
 </manifest>


### PR DESCRIPTION
Hi EA team
To test Cypress's Kong release. The fastest way is to use meta-ea and meta-murata-wireless on bchen-murata's GitHub. Then you will have linux-imx apply all the patches needed for Kong, and meta-murata-wireless for Kong release.
Best regards,
Bill